### PR TITLE
Fix the generation of attachment IDs

### DIFF
--- a/fitconnect/fitconnect.py
+++ b/fitconnect/fitconnect.py
@@ -414,7 +414,7 @@ class FITConnectClient:
 
         submission_request = {
             'destinationId': destination_id,
-            'announcedAttachments': [str(uuid.uuid4())] * num_attachments,
+            'announcedAttachments': [str(uuid.uuid4()) for _ in range(num_attachments)],
             'serviceType': {
                 'name': '', # TODO: auto-fill via leika key
                 'identifier': leika_key


### PR DESCRIPTION
Before:
```python
>>> print([str(uuid.uuid4())] * 3)
['41fa0dd9-269d-41d9-bd27-9f33895da626', '41fa0dd9-269d-41d9-bd27-9f33895da626', '41fa0dd9-269d-41d9-bd27-9f33895da626']
```
(x3 the same UUIDs)

After:
```python
>>> print([str(uuid.uuid4()) for _ in range(3)])
['11f0df84-2a91-4367-83f3-6e1dd7ee43b6', '8378bd8d-363e-482f-9e3c-dbb6b10cb085', '12344e73-625a-4870-be5a-ad27543e9c9f']
```
(x3 different UUIDs)